### PR TITLE
Bump build number for v2.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
   - win32-defs.patch
 
 build:
-  number: 0
+  number: 1
   skip: false
   entry_points:
     - rd_depression_filling=richdem.cli:DepressionFilling


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

It seems that the build number didn't get updated with the most recent build, which meant there were multiple versions of *richdem* 2.3.0 with build number 0. This caused *conda* to get confused as to which version to install (*mamba*, interestingly, found the correct version but maybe that was just luck).

<!--
Please add any other relevant info below:
-->
